### PR TITLE
Add config option to disable update check

### DIFF
--- a/configSchema.json
+++ b/configSchema.json
@@ -27,10 +27,14 @@
     },
     "uninstallMode": {
       "type": "boolean"
+    },
+    "updateCheck": {
+      "type": "boolean"
     }
   },
   "required": [
     "villagerBlacklist",
-    "uninstallMode"
+    "uninstallMode",
+    "updateCheck"
   ]
 }

--- a/src/main/java/me/spartacus04/stackablecuring/Settings.kt
+++ b/src/main/java/me/spartacus04/stackablecuring/Settings.kt
@@ -8,11 +8,13 @@ import org.bukkit.plugin.java.JavaPlugin
  *
  * @property villagerBlacklist The list of blacklisted villagers.
  * @property uninstallMode Indicates if the uninstall mode is enabled.
+ * @property updateCheck Indicates if checking for updates is enabled.
  * @property allowMetrics Indicates if metrics are allowed.
  */
 data class Settings(
     var villagerBlacklist: ArrayList<String> = ArrayList(),
     var uninstallMode: Boolean = false,
+    var updateCheck: Boolean = true,
     var allowMetrics: Boolean = true
 )
 

--- a/src/main/java/me/spartacus04/stackablecuring/StackableCuring.kt
+++ b/src/main/java/me/spartacus04/stackablecuring/StackableCuring.kt
@@ -28,11 +28,13 @@ class StackableCuring : JavaPlugin(), Listener {
         if(CONFIG.allowMetrics)
             Metrics(this, 20757)
 
-        Updater(this).getVersion {
-            if(it != description.version) {
-                Bukkit.getConsoleSender().sendMessage(
-                    "[§aStackableVillagerCuring§f] A new update is available!"
-                )
+        if(CONFIG.updateCheck) {
+            Updater(this).getVersion {
+                if(it != description.version) {
+                    Bukkit.getConsoleSender().sendMessage(
+                        "[§aStackableVillagerCuring§f] A new update is available!"
+                    )
+                }
             }
         }
     }

--- a/src/main/resources/config.json
+++ b/src/main/resources/config.json
@@ -17,6 +17,9 @@
   //Restores the villager trades to their original state.
   "uninstallMode": false,
 
+  //Allow checking for updates.
+  "updateCheck": true,
+
   // Allow/Disallow plugin metrics (no personal data is going to be collected)
   "allow-metrics": true
 }


### PR DESCRIPTION
#### Why
GitHub has a 60 requests/hour rate limit on anonymous requests. When using many plugins, many with update checkers requesting GitHub's API, this limit is quickly reached (especially with many server instances on a velocity network...). I have an update script that caches latest versions and dates (so it isn't limited by the ratelimit because [conditional queries](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api?apiVersion=2022-11-28#use-conditional-requests-if-appropriate)), but this plugin decreases that limit by one per server start.

#### What
This pull requests adds a simple `checkUpdate` config option (defaults to true) and a simple condition check in the plugin initialization when the plugin checks for update.

also, thanks for accepting this on your plugins!